### PR TITLE
Set CONFIG_DIR_NAME only on a VS generator

### DIFF
--- a/icu/source/icudefs.cmake
+++ b/icu/source/icudefs.cmake
@@ -120,7 +120,7 @@ if(WIN32)
 endif()
 
 # overridden by icucross.cmake
-if(MSVC)
+if(CMAKE_GENERATOR MATCHES "Visual Studio.*")
   set(CONFIG_DIR_NAME "/$<CONFIG>")
 endif()
 set(TOOLBINDIR ${BINDIR}${CONFIG_DIR_NAME})


### PR DESCRIPTION
Visual Studio builds have the concept of different configs. MSVC does not mean that VS projects are being used. Instead match the generator.

This makes it so you can use Ninja + MSVC.